### PR TITLE
Basic warmup configuration at swell.json

### DIFF
--- a/swell.json
+++ b/swell.json
@@ -251,7 +251,19 @@
 				"content/blogs": "blogs/blog",
 				"content/pages": "pages/page"
 			},
-			"cache_hook": "/hooks/theme"
+			"cache_hook": "/hooks/theme",
+			"warmup_pages": {
+				"enabled": true,
+				"pages": [
+					"index",
+					"products/index",
+					"categories/index",
+					"blogs/blog",
+					"pages/page",
+					"categories/category",
+					"products/product"
+				]
+			}
 		},
 		"menus": [
 			{


### PR DESCRIPTION
  - Add pages to warmup by their ids at storefront.theme.warmup_pages.pages
  - Drop warmup_pages.pages section to enable all pages of storefront.theme.pages section warmup
  - Drop full warmup_pages section or set warmup_pages.enabled: false to disable warmup