### PR TITLE
reorder middleware by route specificity

### DIFF
--- a/frontend/src/middleware/index.ts
+++ b/frontend/src/middleware/index.ts
@@ -11,10 +11,10 @@ export const onRequest = sequence(
   initLogger,
   htmlCacheMiddleware,
   assetCacheRead,
-  ...globalRoutes,
+  assetRender,
   ...accountRoutes,
   ...cartRoutes,
   ...formRoutes,
-  assetRender,
+  ...globalRoutes,
   restoreThemeRequestData,
 );


### PR DESCRIPTION
https://app.asana.com/1/1126683767705082/project/1207329739803731/task/1211297238456536?focus=true

## Description

Middleware handlers are now ordered by route specificity. Previously, global middleware could intercept requests before more specific ones, causing duplicate `next()` calls and multiple responses. 
With this change, specific routes are matched first, ensuring correct request handling.