### PR TITLE
feat: add swell-storefront-host header

### DIFF
--- a/frontend/src/pages/sitemap.xml.ts
+++ b/frontend/src/pages/sitemap.xml.ts
@@ -23,6 +23,7 @@ export const GET: APIRoute = async (context) => {
   }
 
   const host =
+    context.request.headers.get('swell-storefront-host') ||
     context.request.headers.get('x-forwarded-host') ||
     context.request.headers.get('host') ||
     context.url.host;


### PR DESCRIPTION
https://app.asana.com/1/1126683767705082/project/1202302358229231/task/1215830701980484?focus=true

### Description

- read `swell-storefront-host-header` header and use it as host for sitemap.xml