### PR TITLE
feat: read protocol for sitemap from headers

### DIFF
--- a/frontend/src/pages/sitemap.xml.ts
+++ b/frontend/src/pages/sitemap.xml.ts
@@ -22,6 +22,11 @@ export const GET: APIRoute = async (context) => {
     return new Response(null, { status: 404 });
   }
 
+  const protocol =
+    context.request.headers.get('x-forwarded-proto')?.trim().toLowerCase() ===
+    'https'
+      ? 'https:'
+      : 'http:';
   const host =
     context.request.headers.get('swell-storefront-host') ||
     context.request.headers.get('x-forwarded-host') ||
@@ -53,7 +58,7 @@ export const GET: APIRoute = async (context) => {
   }
 
   const files = await collectSiteLinks(initSwell(context)).then((links) =>
-    generateSitemapFiles(`${context.url.protocol}//${host}`, links),
+    generateSitemapFiles(`${protocol}//${host}`, links),
   );
 
   if (htmlCache) {


### PR DESCRIPTION
### Description

We have fixed the correct domain in https://github.com/swellstores/proxima-app/pull/76, however we are still using `http` as protocol, even when sitemap is opened from `https`:

<img width="958" height="414" alt="image" src="https://github.com/user-attachments/assets/411ccf8c-63da-4527-9152-c7b4a48b5e67" />

We can check header `x-forwarded-proto` for `https` with fallback to `http`